### PR TITLE
Records store data in DictField

### DIFF
--- a/app/models/project_model.py
+++ b/app/models/project_model.py
@@ -6,17 +6,5 @@ from ..models import UserModel
 class ProjectModel(db.Document):
     user = db.ReferenceField(UserModel, reverse_delete_rule=db.CASCADE)
     name = db.StringField(max_length=300, required=True)
-    #    records = db.ListField(db.EmbeddedDocumentField(RecordModel))
-
-    @property
-    def serialize(self):
-        return {'id': str(self.id),
-                'name': self.name,
-                'description': '',
-                'records': [],
-                'access': [],
-                'tags': []}
-
-
 
 

--- a/app/models/record_model.py
+++ b/app/models/record_model.py
@@ -4,11 +4,7 @@ from ..models import ProjectModel
 class RecordModel(db.Document):
     project = db.ReferenceField(ProjectModel, reverse_delete_rule=db.CASCADE)
     label = db.StringField(max_length=300)
+    data = db.DictField()
+    
 
-    @property
-    def serialize(self):
-        return {'id': self.id,
-                'project_id': self.project.id,
-                'label': self.label}
 
-## add class RecordHead


### PR DESCRIPTION
Fix #17

Records lump all the data into the DictField. This allows the data to
have any format.
- Remove serialize method as they are not needed with MongoEngine
- Records reference projects and projects reference users, in one direction
- GET returns correct json
